### PR TITLE
Add NVIDIA_DRIVER_CAPABILITIES in amd64 Docker image

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -18,6 +18,9 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT="1" \
     JELLYFIN_WEB_DIR="/jellyfin/jellyfin-web" \
     JELLYFIN_FFMPEG="/usr/lib/jellyfin-ffmpeg/ffmpeg"
 
+# https://github.com/NVIDIA/nvidia-docker/wiki/Installation-(Native-GPU-Support)
+ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
+
 # Install dependencies:
 #   mesa-va-drivers: needed for AMD VAAPI
 RUN apt-get update \


### PR DESCRIPTION
Set this environment variable in amd64 where it can be picked up
by nvidia-container-runtime or nvidia/k8s-device-plugin to set up
the GPU devices needed for NVENC transcoding.

Fixes #2.