### PR TITLE
Push docker images to ghcr.io alongside DockerHub

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -5,6 +5,9 @@ FROM jellyfin/jellyfin-server:${TARGET_RELEASE}-amd64 as server
 FROM jellyfin/jellyfin-web:${TARGET_RELEASE} as web
 FROM debian:buster-slim
 
+LABEL maintainer="Jellyfin Packaging Team - packaging@jellyfin.org"
+LABEL org.opencontainers.image.source="https://github.com/jellyfin/jellyfin"
+
 # Default environment variables for the Jellyfin invocation
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT="1" \
     LC_ALL="en_US.UTF-8" \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -5,6 +5,10 @@ FROM multiarch/qemu-user-static:x86_64-aarch64 as qemu
 FROM jellyfin/jellyfin-server:${TARGET_RELEASE}-arm64 as server
 FROM jellyfin/jellyfin-web:${TARGET_RELEASE} as web
 FROM arm64v8/debian:buster-slim
+
+LABEL maintainer="Jellyfin Packaging Team - packaging@jellyfin.org"
+LABEL org.opencontainers.image.source="https://github.com/jellyfin/jellyfin"
+
 COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
 
 # Default environment variables for the Jellyfin invocation

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -5,6 +5,10 @@ FROM multiarch/qemu-user-static:x86_64-arm as qemu
 FROM jellyfin/jellyfin-server:${TARGET_RELEASE}-armhf as server
 FROM jellyfin/jellyfin-web:${TARGET_RELEASE} as web
 FROM arm32v7/debian:buster-slim
+
+LABEL maintainer="Jellyfin Packaging Team - packaging@jellyfin.org"
+LABEL org.opencontainers.image.source="https://github.com/jellyfin/jellyfin"
+
 COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin
 
 # Default environment variables for the Jellyfin invocation

--- a/collect-server.azure.sh
+++ b/collect-server.azure.sh
@@ -483,8 +483,11 @@ do_docker_meta() {
 
     # Push the images
     for arch in ${docker_arches[@]}; do
-        echo "Pushing Docker image for ${arch}"
+        echo "Pushing Docker image to DockerHub for ${arch}"
         docker push "${docker_image}":"${cversion}-${arch}" 1>&2
+        echo "Pushing Docker image to ghcr.io for ${arch}"
+        docker tag "${docker_image}":"${cversion}-${arch}" ghcr.io/"${docker_image}":"${cversion}-${arch}" 1>&2
+        docker push ghcr.io/"${docker_image}":"${cversion}-${arch}" 1>&2
     done
 
     # Create the manifests
@@ -496,16 +499,22 @@ do_docker_meta() {
 
     docker manifest create --amend "${docker_image}":"${cversion}" ${image_list_cversion} 1>&2
     docker manifest create --amend "${docker_image}":"${group_tag}" ${image_list_grouptag} 1>&2
+    docker manifest create --amend ghcr.io/"${docker_image}":"${cversion}" ${image_list_cversion} 1>&2
+    docker manifest create --amend ghcr.io/"${docker_image}":"${group_tag}" ${image_list_grouptag} 1>&2
 
     # Push the manifests
-    echo "Pushing Docker image manifests"
+    echo "Pushing Docker image manifests to DockerHub"
     docker manifest push --purge "${docker_image}":"${cversion}" 1>&2
     docker manifest push --purge "${docker_image}":"${group_tag}" 1>&2
+    echo "Pushing Docker image manifests to ghcr.io"
+    docker manifest push --purge ghcr.io/"${docker_image}":"${cversion}" 1>&2
+    docker manifest push --purge ghcr.io/"${docker_image}":"${group_tag}" 1>&2
 
     # Remove images
     for arch in ${docker_arches[@]}; do
         echo "Removing pushed docker image for ${arch}"
         docker image rm "${docker_image}":"${cversion}-${arch}" 1>&2
+        docker image rm ghcr.io/"${docker_image}":"${cversion}-${arch}" 1>&2
     done
     docker image prune --force 1>&2
 

--- a/utils/transfer_ghcr.sh
+++ b/utils/transfer_ghcr.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# One time script to repush docker images from DockerHub to ghcr.io
+username="jellyfin"
+# Github package registry. You need to be logged in first
+target_repo="ghcr.io"
+img_file="image_list.txt"
+tag_file="tag_list.txt"
+rm -rf $img_file
+
+wget -q https://hub.docker.com/v2/repositories/$username/ -O - | jq -r '.results[] | . | .namespace + "/" + .name' >> $img_file
+
+while read -r line; do
+    original_image="$line"
+    new_image="$original_image"
+    rm -rf $tag_file
+    wget -q https://hub.docker.com/v1/repositories/$original_image/tags -O - | jq -r '.[] | .name' >> $tag_file
+
+    while read -r line2; do
+        tag="$line2"
+        docker pull $original_image:$tag
+        docker tag $original_image:$tag $target_repo/$new_image:$tag
+        docker push $target_repo/$new_image:$tag
+    done < "$tag_file"
+
+    while read -r line3; do
+        tag="$line3"
+        # Delete already pushed images
+        docker image rm $original_image:$tag
+        docker image rm $target_repo/$new_image:$tag
+    done < "$tag_file"
+done < "$img_file"
+
+rm -rf $img_file


### PR DESCRIPTION
Fixes #6 

Added a one-time script that can pull all the images from DockerHub and repush them to ghcr.io

Vue related changes at jellyfin/jellyfin-vue#795

We could likely do the same for the non-combined images (jellyfin-server and jellyfin-web) once we rework the build process of them, as right now they're just useless build artifacts for users and they can't really live standalone.

### Setup

All of this requires the system where the scripts are going to run to be logged to the ghcr.io repository. [This section of GitHub help](https://docs.github.com/es/packages/guides/migrating-to-github-container-registry-for-docker-images#authenticating-with-the-container-registry) is all that's needed for having the pushes working

Additionally, my ``transfer_ghcr.sh`` script requires ``jq`` in the system for parsing the JSON from DockerHub responses.

Once the images have been pushed for the first time, they need to have their visibility set to **Public** manually, as they're set to *Private* by default.