### PR TITLE
Ensure Deb metapackage depends on >= this version

### DIFF
--- a/collect-server.azure.sh
+++ b/collect-server.azure.sh
@@ -335,7 +335,7 @@ do_deb_meta() {
         fi
     fi
 
-    sed -i "s/Version: X.Y.Z/Version: ${version}${versend}/g" jellyfin.debian
+    sed -i "s/X.Y.Z/${version}${versend}/g" jellyfin.debian
 
     echo "Building metapackage"
     equivs-build jellyfin.debian 1>&2

--- a/jellyfin.debian
+++ b/jellyfin.debian
@@ -7,7 +7,7 @@ Standards-Version: 3.9.2
 Package: jellyfin
 Version: X.Y.Z
 Maintainer: Jellyfin Packaging Team <packaging@jellyfin.org>
-Depends: jellyfin-server, jellyfin-web, jellyfin-ffmpeg (>= 4.2.1-2)
+Depends: jellyfin-server (>= X.Y.Z), jellyfin-web (>= X.Y.Z), jellyfin-ffmpeg (>= 4.2.1-2)
 Description: Provides the Jellyfin Free Software Media System
  Provides the full Jellyfin experience, including both the server and web interface.
 


### PR DESCRIPTION
Without this, it would be possible to get into a situation where the packages are at versions like:

jellyfin: 10.7.6-1
jellyfin-server: 10.6.4-1
jellyfin-web: 10.6.4-1

Though I'm not sure how this would happen in practice, as reported by the below issue, this will ensure it doesn't happen at all, since upgrading the metapackage would require upgrading the dependency packages too.

Fixes jellyfin/jellyfin#5448