### PR TITLE
ci: new collect server scripts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+tab_width = 4
+indent_size = 4
+indent_style = space
+max_line_length = 9999
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{sh,yaml,yml}]
+tab_width = 2
+indent_size = 2

--- a/.github/workflows/publish-meta-images.yaml
+++ b/.github/workflows/publish-meta-images.yaml
@@ -1,0 +1,249 @@
+name: '🚀 Publish Meta Container Images'
+
+on:
+  repository_dispatch:
+    types:
+      - trigger-meta-container
+  workflow_dispatch:
+    inputs:
+      SERVER_TAG:
+        required: true
+        description: The Jeff server image tag to bundle and the resulting meta image tag.
+      WEB_TAG:
+        required: true
+        description: The Jeff web image tag to bundle.
+      IS_STABLE:
+        required: true
+        description: Is the trigged build a stable release (true, false)
+        default: 'false'
+
+concurrency: meta-container
+
+jobs:
+  setup-vars:
+    name: Setup Variables
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'jellyfin/jellyfin-metapackages' }}
+
+    outputs:
+      stage: ${{ steps.variables.outputs.stage }}
+      server-version: ${{ steps.variables.outputs.server-version }}
+      web-version: ${{ steps.variables.outputs.web-version }}
+      full-tag: ${{ steps.variables.outputs.full-tag }}
+      short-tag: ${{ steps.variables.outputs.short-tag }}
+
+    steps:
+      - name: Setup Stable Environment
+        if: ${{ github.event_name == 'repository_dispatch' && ! github.event.client_payload.unstable }}
+        run: |-
+          VERSION="${{ github.event.client_payload.version }}"
+          echo "STAGE=stable" >> $GITHUB_ENV
+          echo "FULL_TAG=$(echo ${VERSION} | grep -Eo '[0-9]+\.[0-9]+\.[0-9]')" >> $GITHUB_ENV
+          echo "SHORT_TAG=$(echo ${VERSION} | grep -Eo '[0-9]+\.[0-9]+')" >> $GITHUB_ENV
+
+          echo "SERVER_VERSION=$(echo ${VERSION} | grep -Eo '[0-9]+\.[0-9]+\.[0-9]')" >> $GITHUB_ENV
+          echo "WEB_VERSION=$(echo ${VERSION} | grep -Eo '[0-9]+\.[0-9]+\.[0-9]')" >> $GITHUB_ENV
+
+      - name: Setup Unstable Environment
+        if: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.unstable }}
+        run: |-
+          TYPE="${{ github.event.client_payload.type }}"
+          VERSION="${{ github.event.client_payload.version }}"
+          echo "STAGE=unstable" >> $GITHUB_ENV
+          echo "FULL_TAG=$(date -u '+%Y%m%d.%H%M')" >> $GITHUB_ENV
+          echo "SHORT_TAG=$(date -u '+%Y%m%d')" >> $GITHUB_ENV
+
+          if [[ "${TYPE,,}" =~ 'web' ]]; then
+            WEB_VERSION="${VERSION}"
+            SERVER_VERSION="${VERSION%.*}"
+          else
+            WEB_VERSION="${VERSION%.*}"
+            SERVER_VERSION="${VERSION}"
+          fi
+
+          echo "SERVER_VERSION=$(echo ${SERVER_VERSION} | grep -Eo '[0-9]+\.[0-9]+(\.[0-9])?')" >> $GITHUB_ENV
+          echo "WEB_VERSION=$(echo ${WEB_VERSION} | grep -Eo '[0-9]+\.[0-9]+(\.[0-9])?')" >> $GITHUB_ENV
+
+      - name: Setup Manual Environment
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |-
+          SERVER_VERSION="${{ github.event.inputs.SERVER_TAG }}"
+          WEB_VERSION="${{ github.event.inputs.WEB_TAG }}"
+          IS_STABLE="${{ github.event.inputs.IS_STABLE }}"
+
+          if [[ "${IS_STABLE,,}" =~ 'true' ]]; then
+            echo "STAGE=stable" >> $GITHUB_ENV
+            echo "FULL_TAG=$(echo ${SERVER_VERSION} | grep -Eo '[0-9]+\.[0-9]+\.[0-9]')" >> $GITHUB_ENV
+            echo "SHORT_TAG=$(echo ${SERVER_VERSION} | grep -Eo '[0-9]+\.[0-9]+')" >> $GITHUB_ENV
+          else
+            echo "STAGE=unstable" >> $GITHUB_ENV
+            echo "FULL_TAG=$(date -u '+%Y%m%d.%H%M')" >> $GITHUB_ENV
+            echo "SHORT_TAG=$(date -u '+%Y%m%d')" >> $GITHUB_ENV
+          fi
+
+          echo "SERVER_VERSION=$(echo ${SERVER_VERSION} | grep -Eo '[0-9]+\.[0-9]+\.[0-9]')" >> $GITHUB_ENV
+          echo "WEB_VERSION=$(echo ${WEB_VERSION} | grep -Eo '[0-9]+\.[0-9]+\.[0-9]')" >> $GITHUB_ENV
+
+
+      - name: Setup sariables
+        id: variables
+        run: |-
+          echo "::set-output name=stage::${STAGE}"
+          echo "::set-output name=server-version::${SERVER_VERSION}"
+          echo "::set-output name=web-version::${WEB_VERSION}"
+          echo "::set-output name=full-tag::${FULL_TAG}"
+          echo "::set-output name=short-tag::${SHORT_TAG}"
+
+  container-images:
+    name: Build Meta Container Images
+    runs-on: ubuntu-latest
+    needs:
+      - setup-vars
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image-tag: amd64
+            image-config: amd64
+          - image-tag: arm64
+            image-config: arm64
+          - image-tag: armhf
+            image-config: arm32
+
+    env:
+      STAGE: ${{ needs.setup-vars.outputs.stage }}
+      SERVER_VERSION: ${{ needs.setup-vars.outputs.server-version }}
+      WEB_VERSION: ${{ needs.setup-vars.outputs.web-version }}
+      FULL_TAG: ${{ needs.setup-vars.outputs.full-tag }}
+      SHORT_TAG: ${{ needs.setup-vars.outputs.short-tag }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install qemu dependency
+        run: |-
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
+
+      - name: Build meta image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: jellyfin
+          tags: >-
+            ${{ env.STAGE }}-${{ matrix.image-tag }}
+            ${{ env.STAGE }}-${{ env.SHORT_TAG }}-${{ matrix.image-tag }}
+            ${{ env.STAGE }}-${{ env.FULL_TAG }}-${{ matrix.image-tag }}
+          oci: true
+          arch: ${{ matrix.image-config }}
+          dockerfiles: Dockerfile.${{ matrix.image-tag }}
+          context: .
+          build-args: |-
+            STAGE=${{ env.STAGE }}
+            SERVER_VERSION=${{ env.SERVER_VERSION }}
+            WEB_VERSION=${{ env.WEB_VERSION }}
+
+      - name: Publish meta image to ghcr.io
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: ghcr.io/jellyfin
+          username: ${{ github.actor }}
+          password: ${{ secrets.GH_TOKEN }}
+
+      - name: Publish meta image to quay.io
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: quay.io/jellyfin
+          username: jellyfin+github_actions
+          password: ${{ secrets.RH_TOKEN }}
+
+      - name: Publish meta image to docker.io
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: docker.io/jellyfin
+          username: jellyfin
+          password: ${{ secrets.DH_TOKEN }}
+
+  create-manifests:
+    name: Create Container collection manifests
+    runs-on: ubuntu-latest
+    needs:
+      - setup-vars
+      - container-images
+
+    env:
+      STAGE: ${{ needs.setup-vars.outputs.stage }}
+      FULL_TAG: ${{ needs.setup-vars.outputs.full-tag }}
+      SHORT_TAG: ${{ needs.setup-vars.outputs.short-tag }}
+
+    steps:
+      - name: Create manifests
+        run: |-
+          podman manifest create jellyfin:${{ env.STAGE }}
+          if [[ "${{ env.STAGE }}" == 'unstable' ]]; then
+            podman manifest create jellyfin:${{ env.STAGE }}-${{ env.FULL_TAG }}
+            podman manifest create jellyfin:${{ env.STAGE }}-${{ env.SHORT_TAG }}
+          else
+            podman manifest create jellyfin:latest
+            podman manifest create jellyfin:${{ env.FULL_TAG }}
+            podman manifest create jellyfin:${{ env.SHORT_TAG }}
+          fi
+
+      - name: Add images to manifests
+        run: |-
+          for arch in amd64 arm64 armhf; do
+            # will fetch the manifest hash and add it to the manifest (the manifest is identical on all registry)
+            podman manifest add jellyfin:${{ env.STAGE }} docker://ghcr.io/jellyfin/jellyfin:${{ env.STAGE }}-${arch}
+          done
+          if [[ "${{ env.STAGE }}" == 'unstable' ]]; then
+            podman manifest add --all jellyfin:${{ env.STAGE }}-${{ env.FULL_TAG }} jellyfin:${{ env.STAGE }}
+            podman manifest add --all jellyfin:${{ env.STAGE }}-${{ env.SHORT_TAG }} jellyfin:${{ env.STAGE }}
+          else
+            podman manifest add --all jellyfin:latest jellyfin:${{ env.STAGE }}
+            podman manifest add --all jellyfin:${{ env.FULL_TAG }} jellyfin:${{ env.STAGE }}
+            podman manifest add --all jellyfin:${{ env.SHORT_TAG }} jellyfin:${{ env.STAGE }}
+          fi
+
+      - name: Log in to GHCR.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: ghcr.io/jellyfin
+          username: ${{ github.actor }}
+          password: ${{ secrets.GH_TOKEN }}
+
+      - name: Log in to Quay.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: quay.io
+          username: jellyfin+github_actions
+          password: ${{ secrets.RH_TOKEN }}
+
+      - name: Log in to GHCR.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: docker.io
+          username: jellyfin
+          password: ${{ secrets.DH_TOKEN }}
+
+      # I dont like the looks of this but there is currently no better solution
+      - name: Push manifests
+        run: |-
+          for registry in "ghcr.io" "quay.io" "docker.io"; do
+            podman manifest push jellyfin:${{ env.STAGE }} docker://${registry}/jellyfin/jellyfin:${{ env.STAGE }}
+            if [[ "${{ env.STAGE }}" == 'unstable' ]]; then
+              podman manifest push jellyfin:${{ env.STAGE }}-${{ env.FULL_TAG }} docker://${registry}/jellyfin/jellyfin:${{ env.STAGE }}-${{ env.FULL_TAG }}
+              podman manifest push jellyfin:${{ env.STAGE }}-${{ env.SHORT_TAG }} docker://${registry}/jellyfin/jellyfin:${{ env.STAGE }}-${{ env.SHORT_TAG }}
+            else
+              podman manifest push jellyfin:latest docker://${registry}/jellyfin/jellyfin:latest
+              podman manifest push jellyfin:${{ env.FULL_TAG }} docker://${registry}/jellyfin/jellyfin:${{ env.FULL_TAG }}
+              podman manifest push jellyfin:${{ env.SHORT_TAG }} docker://${registry}/jellyfin/jellyfin:${{ env.SHORT_TAG }}
+            fi
+          done

--- a/.github/workflows/publish-meta-images.yaml
+++ b/.github/workflows/publish-meta-images.yaml
@@ -152,7 +152,7 @@ jobs:
           tags: ${{ steps.build-image.outputs.tags }}
           registry: ghcr.io/jellyfin
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_TOKEN }}
+          password: ${{ secrets.JF_BOT_TOKEN }}
 
       - name: Publish meta image to quay.io
         uses: redhat-actions/push-to-registry@v2
@@ -160,8 +160,8 @@ jobs:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}
           registry: quay.io/jellyfin
-          username: jellyfin+github_actions
-          password: ${{ secrets.RH_TOKEN }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Publish meta image to docker.io
         uses: redhat-actions/push-to-registry@v2
@@ -169,8 +169,8 @@ jobs:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}
           registry: docker.io/jellyfin
-          username: jellyfin
-          password: ${{ secrets.DH_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
   create-manifests:
     name: Create Container collection manifests
@@ -217,21 +217,21 @@ jobs:
         with:
           registry: ghcr.io/jellyfin
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_TOKEN }}
+          password: ${{ secrets.JF_BOT_TOKEN }}
 
       - name: Log in to Quay.io
         uses: redhat-actions/podman-login@v1
         with:
           registry: quay.io
-          username: jellyfin+github_actions
-          password: ${{ secrets.RH_TOKEN }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Log in to GHCR.io
         uses: redhat-actions/podman-login@v1
         with:
           registry: docker.io
-          username: jellyfin
-          password: ${{ secrets.DH_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # I dont like the looks of this but there is currently no better solution
       - name: Push manifests

--- a/.github/workflows/publish-meta-images.yaml
+++ b/.github/workflows/publish-meta-images.yaml
@@ -85,7 +85,7 @@ jobs:
           echo "WEB_VERSION=$(echo ${WEB_VERSION} | grep -Eo '[0-9]+\.[0-9]+\.[0-9]')" >> $GITHUB_ENV
 
 
-      - name: Setup sariables
+      - name: Setup variables
         id: variables
         run: |-
           echo "::set-output name=stage::${STAGE}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.deb
+.idea
+.editorconfig

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,22 +1,37 @@
 # By default build for stable; unstable must set this explicitly
-ARG TARGET_RELEASE=stable
+ARG STAGE=stable
+ARG SERVER_VERSION=0.0.0
+ARG WEB_VERSION=0.0.0
 
-FROM jellyfin/jellyfin-server:${TARGET_RELEASE}-amd64 as server
-FROM jellyfin/jellyfin-web:${TARGET_RELEASE} as web
+FROM jellyfin/jellyfin-server:${STAGE}-${SERVER_VERSION}-amd64 as server
+FROM jellyfin/jellyfin-web:${STAGE} as web
 FROM debian:buster-slim
 
 # Default environment variables for the Jellyfin invocation
-ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT="1" \
+ENV DOTNET_CLI_TELEMETRY_OPTOUT="true" \
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT="true" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US:en" \
+    SERVER_VERSION="${SERVER_VERSION:-x.y.z}" \
+    WEB_VERSION="${WEB_VERSION:-x.y.z}" \
     JELLYFIN_MEDIA_DIR="/media" \
     JELLYFIN_DATA_DIR="/config" \
     JELLYFIN_CACHE_DIR="/cache" \
     JELLYFIN_CONFIG_DIR="/config/config" \
     JELLYFIN_LOG_DIR="/config/log" \
-    JELLYFIN_WEB_DIR="/jellyfin/jellyfin-web" \
+    JELLYFIN_WEB_DIR="/opt/jellyfin/jellyfin-web" \
     JELLYFIN_FFMPEG="/usr/lib/jellyfin-ffmpeg/ffmpeg"
+
+# Open Container Initiative metadata labels
+LABEL \
+    org.opencontainers.image.vendor="Jellyfin project" \
+    org.opencontainers.image.title="Official Jellyfin Meta Docker image" \
+    org.opencontainers.image.description="Jellyfin - The Free Software Media System" \
+    org.opencontainers.image.version="${SERVER_VERSION}" \
+    org.opencontainers.image.url="https://jellyfin.org/" \
+    org.opencontainers.image.source="https://github.com/jellyfin/jellyfin-metapackages" \
+    org.opencontainers.image.licenses="GPL-2.0"
 
 # https://github.com/intel/compute-runtime/releases
 ARG GMMLIB_VERSION=20.3.2
@@ -26,38 +41,38 @@ ARG LEVEL_ZERO_VERSION=1.0.18421
 
 # Install dependencies:
 # mesa-va-drivers: needed for AMD VAAPI. Mesa >= 20.1 is required for HEVC transcoding.
-RUN apt-get update \
- && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg wget apt-transport-https \
- && wget -O - https://repo.jellyfin.org/jellyfin_team.gpg.key | apt-key add - \
- && echo 'deb [arch=amd64] https://repo.jellyfin.org/debian buster main' > /etc/apt/sources.list.d/jellyfin.list \
- && cat /etc/apt/sources.list.d/jellyfin.list \
- && apt-get update \
- && apt-get install --no-install-recommends --no-install-suggests -y mesa-va-drivers jellyfin-ffmpeg openssl locales libfontconfig1 libfreetype6 \
+RUN apt-get update -yqq \
+    && apt-get install --no-install-recommends --no-install-suggests -yqq ca-certificates gnupg wget apt-transport-https \
+    && wget -qO - https://repo.jellyfin.org/jellyfin_team.gpg.key | apt-key add - \
+    && echo 'deb [arch=amd64] https://repo.jellyfin.org/debian buster main' > /etc/apt/sources.list.d/jellyfin.list \
+    && cat /etc/apt/sources.list.d/jellyfin.list \
+    && apt-get update -yqq \
+    && apt-get install --no-install-recommends --no-install-suggests -yqq mesa-va-drivers jellyfin-ffmpeg openssl locales libfontconfig1 libfreetype6 \
 # Intel VAAPI Tone mapping dependencies:
 # Prefer NEO to Beignet since the latter one doesn't support Comet Lake or newer for now.
 # Do not use the intel-opencl-icd package from repo since they will not build with RELEASE_WITH_REGKEYS enabled.
- && mkdir intel-compute-runtime \
- && cd intel-compute-runtime \
- && wget https://github.com/intel/compute-runtime/releases/download/${NEO_VERSION}/intel-gmmlib_${GMMLIB_VERSION}_amd64.deb \
- && wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-${IGC_VERSION}/intel-igc-core_${IGC_VERSION}_amd64.deb \
- && wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-${IGC_VERSION}/intel-igc-opencl_${IGC_VERSION}_amd64.deb \
- && wget https://github.com/intel/compute-runtime/releases/download/${NEO_VERSION}/intel-opencl_${NEO_VERSION}_amd64.deb \
- && wget https://github.com/intel/compute-runtime/releases/download/${NEO_VERSION}/intel-ocloc_${NEO_VERSION}_amd64.deb \
- && wget https://github.com/intel/compute-runtime/releases/download/${NEO_VERSION}/intel-level-zero-gpu_${LEVEL_ZERO_VERSION}_amd64.deb \
- && dpkg -i *.deb \
- && cd .. \
- && rm -rf intel-compute-runtime \
- && apt-get remove gnupg wget apt-transport-https -y \
- && apt-get clean autoclean -y \
- && apt-get autoremove -y \
- && rm -rf /var/lib/apt/lists/* \
- && mkdir -p ${JELLYFIN_MEDIA_DIR} ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
- && chmod 777 ${JELLYFIN_MEDIA_DIR} ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
- && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
+    && mkdir intel-compute-runtime \
+    && cd intel-compute-runtime \
+    && wget -q https://github.com/intel/compute-runtime/releases/download/${NEO_VERSION}/intel-gmmlib_${GMMLIB_VERSION}_amd64.deb \
+    && wget -q https://github.com/intel/intel-graphics-compiler/releases/download/igc-${IGC_VERSION}/intel-igc-core_${IGC_VERSION}_amd64.deb \
+    && wget -q https://github.com/intel/intel-graphics-compiler/releases/download/igc-${IGC_VERSION}/intel-igc-opencl_${IGC_VERSION}_amd64.deb \
+    && wget -q https://github.com/intel/compute-runtime/releases/download/${NEO_VERSION}/intel-opencl_${NEO_VERSION}_amd64.deb \
+    && wget -q https://github.com/intel/compute-runtime/releases/download/${NEO_VERSION}/intel-ocloc_${NEO_VERSION}_amd64.deb \
+    && wget -q https://github.com/intel/compute-runtime/releases/download/${NEO_VERSION}/intel-level-zero-gpu_${LEVEL_ZERO_VERSION}_amd64.deb \
+    && dpkg -i *.deb \
+    && cd .. \
+    && rm -rf intel-compute-runtime \
+    && apt-get remove gnupg wget apt-transport-https -yqq \
+    && apt-get clean autoclean -yqq \
+    && apt-get autoremove -yqq \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p ${JELLYFIN_MEDIA_DIR} ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
+    && chmod 777 ${JELLYFIN_MEDIA_DIR} ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
+    && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
 
-COPY --from=server /jellyfin /jellyfin
-COPY --from=web /jellyfin-web /jellyfin/jellyfin-web
+COPY --from=server /opt/jellyfin /opt/jellyfin
+COPY --from=web /opt/jellyfin-web /opt/jellyfin/jellyfin-web
 
-EXPOSE 8096
-VOLUME ${JELLYFIN_MEDIA_DIR} ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR}
-ENTRYPOINT [ "/jellyfin/jellyfin" ]
+EXPOSE 8096/tcp
+VOLUME [ "${JELLYFIN_MEDIA_DIR}", "${JELLYFIN_DATA_DIR}", "${JELLYFIN_CACHE_DIR}" ]
+ENTRYPOINT [ "/opt/jellyfin/jellyfin" ]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,44 +1,59 @@
 # By default build for stable; unstable must set this explicitly
-ARG TARGET_RELEASE=stable
+ARG STAGE=stable
+ARG SERVER_VERSION=0.0.0
+ARG WEB_VERSION=0.0.0
 
 FROM multiarch/qemu-user-static:x86_64-aarch64 as qemu
-FROM jellyfin/jellyfin-server:${TARGET_RELEASE}-arm64 as server
-FROM jellyfin/jellyfin-web:${TARGET_RELEASE} as web
+FROM jellyfin/jellyfin-server:${STAGE}-${SERVER_VERSION}-amd64 as server
+FROM jellyfin/jellyfin-web:${STAGE} as web
 FROM arm64v8/debian:buster-slim
 COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
 
 # Default environment variables for the Jellyfin invocation
-ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT="1" \
+ENV DOTNET_CLI_TELEMETRY_OPTOUT="true" \
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT="true" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US:en" \
+    SERVER_VERSION="${SERVER_VERSION:-x.y.z}" \
+    WEB_VERSION="${WEB_VERSION:-x.y.z}" \
     JELLYFIN_MEDIA_DIR="/media" \
     JELLYFIN_DATA_DIR="/config" \
     JELLYFIN_CACHE_DIR="/cache" \
     JELLYFIN_CONFIG_DIR="/config/config" \
     JELLYFIN_LOG_DIR="/config/log" \
-    JELLYFIN_WEB_DIR="/jellyfin/jellyfin-web" \
+    JELLYFIN_WEB_DIR="/opt/jellyfin/jellyfin-web" \
     JELLYFIN_FFMPEG="/usr/lib/jellyfin-ffmpeg/ffmpeg"
+
+# Open Container Initiative metadata labels
+LABEL \
+    org.opencontainers.image.vendor="Jellyfin project" \
+    org.opencontainers.image.title="Official Jellyfin Meta Docker image" \
+    org.opencontainers.image.description="Jellyfin - The Free Software Media System" \
+    org.opencontainers.image.version="${SERVER_VERSION}" \
+    org.opencontainers.image.url="https://jellyfin.org/" \
+    org.opencontainers.image.source="https://github.com/jellyfin/jellyfin-metapackages" \
+    org.opencontainers.image.licenses="GPL-2.0"
 
 # Install dependencies:
 #   libomxil-bellagio0: needed for OpenMax IL
-RUN apt-get update \
- && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg wget apt-transport-https \
- && wget -O - https://repo.jellyfin.org/jellyfin_team.gpg.key | apt-key add - \
- && echo 'deb [arch=arm64] https://repo.jellyfin.org/debian buster main' > /etc/apt/sources.list.d/jellyfin.list \
- && apt-get update \
- && apt-get install --no-install-recommends --no-install-suggests -y libomxil-bellagio0 libomxil-bellagio-bin jellyfin-ffmpeg openssl locales libfontconfig1 libfreetype6 \
- && apt-get remove gnupg wget apt-transport-https -y \
- && apt-get clean autoclean -y \
- && apt-get autoremove -y \
- && rm -rf /var/lib/apt/lists/* \
- && mkdir -p ${JELLYFIN_MEDIA_DIR} ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
- && chmod 777 ${JELLYFIN_MEDIA_DIR} ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
- && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
+RUN apt-get update -yqq \
+    && apt-get install --no-install-recommends --no-install-suggests -yqq ca-certificates gnupg wget apt-transport-https \
+    && wget -qO - https://repo.jellyfin.org/jellyfin_team.gpg.key | apt-key add - \
+    && echo 'deb [arch=arm64] https://repo.jellyfin.org/debian buster main' > /etc/apt/sources.list.d/jellyfin.list \
+    && apt-get update \
+    && apt-get install --no-install-recommends --no-install-suggests -yqq libomxil-bellagio0 libomxil-bellagio-bin jellyfin-ffmpeg openssl locales libfontconfig1 libfreetype6 \
+    && apt-get remove gnupg wget apt-transport-https -yqq \
+    && apt-get clean autoclean -yqq \
+    && apt-get autoremove -yqq \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p ${JELLYFIN_MEDIA_DIR} ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
+    && chmod 777 ${JELLYFIN_MEDIA_DIR} ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
+    && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
 
-COPY --from=server /jellyfin /jellyfin
-COPY --from=web /jellyfin-web /jellyfin/jellyfin-web
+COPY --from=server /opt/jellyfin /opt/jellyfin
+COPY --from=web /opt/jellyfin-web /opt/jellyfin/jellyfin-web
 
-EXPOSE 8096
-VOLUME ${JELLYFIN_MEDIA_DIR} ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR}
-ENTRYPOINT [ "/jellyfin/jellyfin" ]
+EXPOSE 8096/tcp
+VOLUME [ "${JELLYFIN_MEDIA_DIR}", "${JELLYFIN_DATA_DIR}", "${JELLYFIN_CACHE_DIR}" ]
+ENTRYPOINT [ "/opt/jellyfin/jellyfin" ]

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,48 +1,63 @@
 # By default build for stable; unstable must set this explicitly
-ARG TARGET_RELEASE=stable
+ARG STAGE=stable
+ARG SERVER_VERSION=0.0.0
+ARG WEB_VERSION=0.0.0
 
 FROM multiarch/qemu-user-static:x86_64-arm as qemu
-FROM jellyfin/jellyfin-server:${TARGET_RELEASE}-armhf as server
-FROM jellyfin/jellyfin-web:${TARGET_RELEASE} as web
+FROM jellyfin/jellyfin-server:${STAGE}-${SERVER_VERSION}-amd64 as server
+FROM jellyfin/jellyfin-web:${STAGE} as web
 FROM arm32v7/debian:buster-slim
 COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin
 
 # Default environment variables for the Jellyfin invocation
-ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT="1" \
+ENV DOTNET_CLI_TELEMETRY_OPTOUT="true" \
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT="true" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US:en" \
+    SERVER_VERSION="${SERVER_VERSION:-x.y.z}" \
+    WEB_VERSION="${WEB_VERSION:-x.y.z}" \
     JELLYFIN_MEDIA_DIR="/media" \
     JELLYFIN_DATA_DIR="/config" \
     JELLYFIN_CACHE_DIR="/cache" \
     JELLYFIN_CONFIG_DIR="/config/config" \
     JELLYFIN_LOG_DIR="/config/log" \
-    JELLYFIN_WEB_DIR="/jellyfin/jellyfin-web" \
+    JELLYFIN_WEB_DIR="/opt/jellyfin/jellyfin-web" \
     JELLYFIN_FFMPEG="/usr/lib/jellyfin-ffmpeg/ffmpeg"
+
+# Open Container Initiative metadata labels
+LABEL \
+    org.opencontainers.image.vendor="Jellyfin project" \
+    org.opencontainers.image.title="Official Jellyfin Meta Docker image" \
+    org.opencontainers.image.description="Jellyfin - The Free Software Media System" \
+    org.opencontainers.image.version="${SERVER_VERSION}" \
+    org.opencontainers.image.url="https://jellyfin.org/" \
+    org.opencontainers.image.source="https://github.com/jellyfin/jellyfin-metapackages" \
+    org.opencontainers.image.licenses="GPL-2.0"
 
 # Install dependencies:
 #   libomxil-bellagio0: needed for OpenMax IL
 #   libraspberrypi0: needed for MMAL component of ffmpeg (from Raspberry Pi)
 #   libva2: needed for VAAPI
-RUN apt-get update \
- && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg wget apt-transport-https \
- && wget -O - https://repo.jellyfin.org/jellyfin_team.gpg.key | apt-key add - \
- && wget -O - https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x6587ffd6536b8826e88a62547876ae518cbcf2f2 | apt-key add - \
- && echo 'deb [arch=armhf] https://repo.jellyfin.org/debian buster main' > /etc/apt/sources.list.d/jellyfin.list \
- && echo 'deb http://ppa.launchpad.net/ubuntu-raspi2/ppa-nightly/ubuntu focal main'>> /etc/apt/sources.list.d/raspbins.list \
- && apt-get update \
- && apt-get install --no-install-recommends --no-install-suggests -y libva2 vainfo libraspberrypi0 libomxil-bellagio0 libomxil-bellagio-bin jellyfin-ffmpeg openssl locales libfontconfig1 libfreetype6 \
- && apt-get remove gnupg wget apt-transport-https -y \
- && apt-get clean autoclean -y \
- && apt-get autoremove -y \
- && rm -rf /var/lib/apt/lists/* \
- && mkdir -p ${JELLYFIN_MEDIA_DIR} ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
- && chmod 777 ${JELLYFIN_MEDIA_DIR} ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
- && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
+RUN apt-get update -yqq \
+    && apt-get install --no-install-recommends --no-install-suggests -yqq ca-certificates gnupg wget apt-transport-https \
+    && wget -O - https://repo.jellyfin.org/jellyfin_team.gpg.key | apt-key add - \
+    && wget -O - https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x6587ffd6536b8826e88a62547876ae518cbcf2f2 | apt-key add - \
+    && echo 'deb [arch=armhf] https://repo.jellyfin.org/debian buster main' > /etc/apt/sources.list.d/jellyfin.list \
+    && echo 'deb http://ppa.launchpad.net/ubuntu-raspi2/ppa-nightly/ubuntu focal main'>> /etc/apt/sources.list.d/raspbins.list \
+    && apt-get update \
+    && apt-get install --no-install-recommends --no-install-suggests -yqq libva2 vainfo libraspberrypi0 libomxil-bellagio0 libomxil-bellagio-bin jellyfin-ffmpeg openssl locales libfontconfig1 libfreetype6 \
+    && apt-get remove gnupg wget apt-transport-https -yqq \
+    && apt-get clean autoclean -yqq \
+    && apt-get autoremove -yqq \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p ${JELLYFIN_MEDIA_DIR} ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
+    && chmod 777 ${JELLYFIN_MEDIA_DIR} ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
+    && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
 
-COPY --from=server /jellyfin /jellyfin
-COPY --from=web /jellyfin-web /jellyfin/jellyfin-web
+COPY --from=server /opt/jellyfin /opt/jellyfin
+COPY --from=web /opt/jellyfin-web /opt/jellyfin/jellyfin-web
 
-EXPOSE 8096
-VOLUME ${JELLYFIN_MEDIA_DIR} ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR}
-ENTRYPOINT [ "/jellyfin/jellyfin" ]
+EXPOSE 8096/tcp
+VOLUME [ "${JELLYFIN_MEDIA_DIR}", "${JELLYFIN_DATA_DIR}", "${JELLYFIN_CACHE_DIR}" ]
+ENTRYPOINT [ "/opt/jellyfin/jellyfin" ]

--- a/collect-server.os-packs.sh
+++ b/collect-server.os-packs.sh
@@ -1,0 +1,499 @@
+#!/usr/bin/env bash
+
+# Jellyfin OS package builds collection script
+# Parses the artifacts uploaded from CI build and puts them into place, as well as building the various meta-packages and meta-archives
+
+logfile="/var/log/build/os-pack.log"
+exec 2>>${logfile}
+
+# Ensure we're running as root (i.e. sudo $0)
+if [[ $( whoami ) != 'root' ]]; then
+    echo "Script must be run as root"
+fi
+
+time_start=$( date +%s )
+
+# Static variables
+repo_dir="/srv/jellyfin"
+metapackages_dir="${repo_dir}/projects/server/jellyfin-metapackages"
+docker_arches=(
+  "amd64"
+  "arm64"
+  "armhf"
+)
+releases_debian=(
+  "stretch"
+  "buster"
+  "bullseye"
+)
+releases_ubuntu=(
+  "xenial"
+  "bionic"
+  "focal"
+  "groovy"
+)
+
+echo "**********" 1>&2
+date 1>&2
+echo "**********" 1>&2
+
+set -o xtrace
+
+# Get our input arguments
+echo ${0} ${@} 1>&2
+in_dir="${1}"
+build_id="${2}"
+version="${3}"
+stage="${4}"
+artifact_type="${5}"
+
+if [[ "${stage}" =~ [Uu]nstable ]]; then
+    is_unstable='unstable'
+else
+    is_unstable=''
+fi
+
+# Abort if we're missing arguments
+if [[ -z ${in_dir} || -z ${build_id} || -z ${version} || -z ${stage} || -z ${artifact_type} ]]; then
+  echo "One or more of the required script parameters is missing!"
+  exit 1
+fi
+
+if [[ ${stage} =~ [Ss]table && ${version} =~ "-rc" ]]; then
+    echo "This is an RC"
+    is_rc="rc"
+else
+    is_rc=""
+fi
+
+do_deb() {
+  if [[ -n ${is_rc} ]]; then
+    return
+  fi
+
+  platform_arch="${1}"
+  platform="${platform_arch%.*}"
+  case ${platform} in
+    debian)
+      releases=( ${releases_debian[@]} )
+    ;;
+    ubuntu)
+      releases=( ${releases_ubuntu[@]} )
+    ;;
+  esac
+
+  repo_dir="/srv/repository/${platform}"
+
+  if [[ -z ${is_unstable} ]]; then
+    component="-C main"
+  else
+    component="-C unstable"
+  fi
+
+  # Reprepro repository
+  for release in ${releases[@]}; do
+    echo "Importing files into ${release}"
+    reprepro -b ${repo_dir} --export=never --keepunreferencedfiles \
+      ${component} \
+      includedeb \
+      ${release} \
+      ${in_dir}/${build_id}/${platform_arch}/*.deb
+  done
+  echo "Cleaning and exporting repository"
+  reprepro -b ${repo_dir} deleteunreferenced
+  reprepro -b ${repo_dir} export
+  chown -R root:adm ${repo_dir}
+  chmod -R g+w ${repo_dir}
+}
+
+# Static files collection function
+do_files() {
+  platform_arch="${1}"
+  platform="${platform_arch%.*}" # Strip off the architecture
+  if [[ ${platform} == 'windows-installer' ]]; then
+    platform="windows"
+    artifact_type="installer"
+  fi
+  file_dir="/srv/repository/releases/server/${platform}"
+
+  if [[ -n ${is_unstable} ]]; then
+    release_dir="versions/unstable/${artifact_type}/${version}"
+    link_dir="unstable"
+  elif [[ -n ${is_rc} ]]; then
+    release_dir="versions/stable-rc/${artifact_type}/${version}"
+    link_dir="stable-rc"
+  else
+    release_dir="versions/stable/${artifact_type}/${version}"
+    link_dir="stable"
+  fi
+
+  # Static files
+  echo "Creating release directory"
+  mkdir -p ${file_dir}/${release_dir}
+  mkdir -p ${file_dir}/${link_dir}
+  if [[ -L ${file_dir}/${link_dir}/${artifact_type} ]]; then
+    rm -f ${file_dir}/${link_dir}/${artifact_type}
+  fi
+  ln -s ../${release_dir} ${file_dir}/${link_dir}/${artifact_type}
+  echo "Copying files"
+  mv ${in_dir}/${build_id}/${platform_arch}/* ${file_dir}/${release_dir}/
+  echo "Creating sha256sums"
+  for file in ${file_dir}/${release_dir}/*; do
+    if [[ ${file} =~ ".sha256sum" ]]; then
+      continue
+    fi
+    sha256sum ${file} | sed 's, .*/, ,' > ${file}.sha256sum
+  done
+  echo "Cleaning repository"
+  chown -R root:adm ${file_dir}
+  chmod -R g+w ${file_dir}
+}
+
+# Portable archive combination function
+do_combine_portable() {
+  platform_arch="${1}"
+  platform="${platform_arch%.*}"
+  case ${artifact_type} in
+    server)
+      partner_type="web"
+      file_dir="/srv/repository/releases/server/${platform}"
+    ;;
+    web)
+      partner_type="server"
+      file_dir="/srv/repository/releases/server/${platform}"
+    ;;
+  esac
+
+  if [[ ${platform} == "windows" ]]; then
+    filetype="zip"
+  else
+    filetype="tar.gz"
+  fi
+
+  if [[ -n ${is_unstable} ]]; then
+    stability="unstable"
+    pkg_suffix="-unstable"
+  elif [[ -n ${is_rc} ]]; then
+    stability="stable-rc"
+    pkg_suffix=""
+  else
+    stability="stable"
+    pkg_suffix=""
+  fi
+  release_dir="versions/${stability}/${artifact_type}"
+  partner_release_dir="versions/${stability}/${partner_type}"
+  link_dir="${stability}/combined"
+
+  our_archive="$( find ${file_dir}/${release_dir}/${version} -type f -name "jellyfin-${artifact_type}*.${filetype}" | head -1 )"
+  if [[ -z ${is_unstable} ]]; then
+    partner_archive="$( find ${file_dir}/${partner_release_dir} -type f -name "*${version}*.${filetype}" -printf "%T@ %Tc %p\n" | sort -rn | head -1 | awk '{ print $NF }' )"
+  else
+    partner_archive="$( find ${file_dir}/${partner_release_dir} -type f -name "*.${filetype}" -printf "%T@ %Tc %p\n" | sort -rn | head -1 | awk '{ print $NF }' )"
+  fi
+
+  if [[ ! -f ${partner_archive} ]]; then
+    return
+  fi
+
+  temp_dir=$( mktemp -d )
+  case ${artifact_type} in
+    server)
+      server_archive="${our_archive}"
+      web_archive="${partner_archive}"
+    ;;
+    web)
+      server_archive="${partner_archive}"
+      web_archive="${our_archive}"
+    ;;
+  esac
+
+  echo "Unarchiving server archive"
+  if [[ ${filetype} == "zip" ]]; then
+    unzip ${server_archive} -d ${temp_dir}/ &>/dev/null
+  else
+    tar -xzf ${server_archive} -C ${temp_dir}/
+  fi
+
+  echo "Correcting root directory naming"
+  pushd ${temp_dir} 1>&2
+  server_dir="$( find . -maxdepth 1 -type d -name "jellyfin-server_*" | head -1 )"
+  mv ${server_dir} ./jellyfin_${version}
+  popd 1>&2
+
+  echo "Unarchiving web archive"
+  if [[ ${filetype} == "zip" ]]; then
+    unzip ${web_archive} -d ${temp_dir}/jellyfin_${version}/ &>/dev/null
+  else
+    tar -xzf ${web_archive} -C ${temp_dir}/jellyfin_${version}/
+  fi
+
+  echo "Correcting web directory naming"
+  pushd ${temp_dir}/jellyfin_${version}/ 1>&2
+  web_dir="$( find . -maxdepth 1 -type d -name "jellyfin-web_*" | head -1 )"
+  mv ${web_dir} jellyfin-web
+  popd 1>&2
+
+  pushd ${temp_dir} 1>&2
+  mkdir -p ${file_dir}/versions/${stability}/combined/${version}
+  if [[ ${filetype} == "zip" ]]; then
+    echo "Creating combined zip archive"
+    chown -R root:root ./
+    zip -r ${file_dir}/versions/${stability}/combined/${version}/jellyfin_${version}${pkg_suffix}.zip ./* &>/dev/null
+    echo "Creating sha256sums"
+    sha256sum ${file_dir}/versions/${stability}/combined/${version}/jellyfin_${version}${pkg_suffix}.zip | sed 's, .*/, ,' > ${file_dir}/versions/${stability}/combined/${version}/jellyfin_${version}${pkg_suffix}.zip.sha256sum
+  else
+    echo "Creating combined tar archive"
+    chown -R root:root ./
+    tar -czf ${file_dir}/versions/${stability}/combined/${version}/jellyfin_${version}${pkg_suffix}.tar.gz ./
+    echo "Creating sha256sums"
+    sha256sum ${file_dir}/versions/${stability}/combined/${version}/jellyfin_${version}${pkg_suffix}.tar.gz | sed 's, .*/, ,' > ${file_dir}/versions/${stability}/combined/${version}/jellyfin_${version}${pkg_suffix}.tar.gz.sha256sum
+  fi
+  popd 1>&2
+
+  echo "Creating links"
+  if [[ -L ${file_dir}/${link_dir} ]]; then
+    rm -f ${file_dir}/${link_dir}
+  fi
+  ln -s ../versions/${stability}/combined/${version} ${file_dir}/${link_dir}
+
+  echo "Cleaning up"
+  rm -rf ${temp_dir}
+}
+
+# Debian Metapackage function
+do_deb_meta() {
+  platform_arch="${1}"
+  platform="${platform_arch%.*}"
+  pushd ${metapackages_dir} 1>&2
+
+  case ${platform} in
+    debian)
+      codename="buster"
+    ;;
+    ubuntu)
+      codename="bionic"
+    ;;
+  esac
+
+  file_dir="/srv/repository/releases/server/${platform}"
+
+  if [[ -n ${is_unstable} ]]; then
+    release_dir="versions/unstable/meta/${version}"
+    link_dir="unstable"
+    version_suffix="-unstable"
+  elif [[ -n ${is_rc} ]]; then
+    release_dir="versions/stable-rc/meta/${version}"
+    link_dir="stable-rc"
+    version_suffix=""
+  else
+    release_dir="versions/stable/meta/${version}"
+    link_dir="stable"
+    version_suffix="-1"
+  fi
+
+  if [[ -z ${is_unstable} && -n ${is_rc} ]]; then
+    # Check if we're the first one done and abandon this if so (let the last build trigger the metapackage)
+    if [[
+      $( reprepro -b /srv/repository/${platform} -C main list ${codename} jellyfin-web | awk '{ print $NF }' | sort | uniq | grep -F "${version}" | wc -l ) -lt 1
+      &&
+      $( reprepro -b /srv/repository/${platform} -C main list ${codename} jellyfin-server | awk '{ print $NF }' | sort | uniq | grep -F "${version}" | wc -l ) -lt 1
+    ]]; then
+      return
+    fi
+
+    # For stable releases, fix our dependency to the version
+    server_checkstring="(>=${version}-0)"
+    web_checkstring="(>=${version}-0)"
+    sed -i "s/Depends: jellyfin-server, jellyfin-web/Depends: jellyfin-server ${server_checkstring}, jellyfin-web ${web_checkstring}/g" jellyfin.debian
+  fi
+
+  # Check if there's already a metapackage (e.g. this is the second or later arch for this platform)
+  if [[ -n ${is_rc} ]]; then
+    if [[ $( reprepro -b /srv/repository/${platform} -C main list ${codename} jellyfin | awk '{ print $NF }' | sort | uniq | grep -F "${version}" | wc -l ) -gt 0 ]]; then
+      return
+    fi
+  fi
+
+  sed -i "s/X.Y.Z/${version}${version_suffix}/g" jellyfin.debian
+
+  echo "Building metapackage"
+  equivs-build jellyfin.debian 1>&2
+
+  case ${platform} in
+    debian)
+      release=( ${releases_debian[@]} )
+    ;;
+    ubuntu)
+      release=( ${releases_ubuntu[@]} )
+    ;;
+  esac
+
+  repo_dir="/srv/repository/${platform}"
+
+  if [[ -z ${is_rc} ]]; then
+    if [[ -z ${is_unstable} ]]; then
+      component="-C main"
+    else
+      component="-C unstable"
+    fi
+
+    # Reprepro repository
+    for release in ${releases[@]}; do
+      echo "Importing files into ${release}"
+      reprepro -b ${repo_dir} --export=never --keepunreferencedfiles \
+        ${component} \
+        includedeb \
+        ${release} \
+        ./*.deb
+    done
+    echo "Cleaning and exporting repository"
+    reprepro -b ${repo_dir} deleteunreferenced
+    reprepro -b ${repo_dir} export
+    chown -R root:adm ${repo_dir}
+    chmod -R g+w ${repo_dir}
+  fi
+
+  # Static files
+  echo "Creating release directory"
+  mkdir -p ${file_dir}/${release_dir}
+  mkdir -p ${file_dir}/${link_dir}
+  if [[ -L ${file_dir}/${link_dir}/meta ]]; then
+      rm -f ${file_dir}/${link_dir}/meta
+  fi
+  ln -s ../${release_dir} ${file_dir}/${link_dir}/meta
+  echo "Copying files"
+  mv ./*.deb ${file_dir}/${release_dir}/
+  echo "Creating sha256sums"
+  for file in ${file_dir}/${release_dir}/*.deb; do
+    if [[ ${file} =~ "*.sha256sum" ]]; then
+      continue
+    fi
+    sha256sum ${file} | sed 's, .*/, ,' > ${file}.sha256sum
+  done
+  echo "Cleaning repository"
+  chown -R root:adm ${file_dir}
+  chmod -R g+w ${file_dir}
+
+  # Clean up our changes
+  git checkout jellyfin.debian
+
+  popd 1>&2
+}
+
+cleanup_unstable() {
+  platform_arch="${1}"
+  platform="${platform_arch%.*}"
+  if [[ ${stage} =~ [Ss]table ]]; then
+    return
+  fi
+  file_dir="/srv/repository/releases/server/${platform}/versions/unstable"
+  find ${file_dir} -mindepth 2 -maxdepth 2 -type d -mtime +3 -exec rm -r {} \;
+}
+
+(
+  # Acquire an exclusive lock so multiple simultaneous builds do not override each other
+  flock -x 300
+
+  # Ensure Metapackages repo is cloned and up-to-date
+  echo "Ensuring metapackages repo is up to date"
+  pushd ${repo_dir} 1>&2
+  ./build.py --clone-only jellyfin-metapackages 1>&2
+  popd 1>&2
+  pushd ${metapackages_dir} 1>&2
+  git checkout master 1>&2
+  git fetch --all 1>&2
+  git stash 1>&2
+  git pull --rebase 1>&2
+  popd 1>&2
+
+  # Main loop
+  for directory in ${in_dir}/${build_id}/*; do
+    platform_arch="$( awk -F'/' '{ print $NF }' <<<"${directory}" )"
+    echo "> Processing ${platform_arch}"
+    case ${platform_arch} in
+      debian*)
+        do_deb ${platform_arch}
+        do_deb_meta ${platform_arch}
+        do_files ${platform_arch}
+        cleanup_unstable ${platform_arch}
+      ;;
+      ubuntu*)
+        do_deb ${platform_arch}
+        do_deb_meta ${platform_arch}
+        do_files ${platform_arch}
+        cleanup_unstable ${platform_arch}
+      ;;
+      fedora*)
+        do_files ${platform_arch}
+        cleanup_unstable ${platform_arch}
+      ;;
+      centos*)
+        do_files ${platform_arch}
+        cleanup_unstable ${platform_arch}
+      ;;
+      portable)
+        do_files ${platform_arch}
+        do_combine_portable ${platform_arch}
+        cleanup_unstable ${platform_arch}
+      ;;
+      linux*)
+        do_files ${platform_arch}
+        do_combine_portable ${platform_arch}
+        cleanup_unstable ${platform_arch}
+      ;;
+      windows-installer*)
+        # Modify the version info of the package if unstable
+        if [[ -n ${is_unstable} ]]; then
+          echo "Renaming Windows installer file to unstable version name"
+          pushd ${in_dir}/${build_id}/${platform_arch} 1>&2
+          # Correct the version
+          mmv "jellyfin_*_windows-x64.exe" "jellyfin_${build_id}-unstable_x64.exe" 1>&2
+          # Redo the version
+          version="${build_id}"
+          popd 1>&2
+        fi
+
+        do_files ${platform_arch}
+        cleanup_unstable windows # Manual set to avoid override
+
+        # Skip Docker, since this is not a real build
+        skip_docker="true"
+      ;;
+      windows*)
+        # Trigger the installer build; this is done here due to convolutions doing it in the CI itself
+        #if [[ -n ${is_unstable} ]]; then
+        #    echo "Triggering pipeline build for Windows Installer (unstable)"
+        #    #az pipelines build queue --organization https://dev.azure.com/jellyfin-project --project jellyfin --definition-id 30 --branch master --variables Trigger="Unstable" 1>&2
+        #else
+        #    echo "Triggering pipeline build for Windows Installer (stable v${version})"
+        #    #az pipelines build queue --organization https://dev.azure.com/jellyfin-project --project jellyfin --definition-id 30 --branch master --variables Trigger="Stable" TagName="v${version}" 1>&2
+        #fi
+
+        do_files ${platform_arch}
+        do_combine_portable ${platform_arch}
+        cleanup_unstable ${platform_arch}
+      ;;
+      macos*)
+        do_files ${platform_arch}
+        do_combine_portable ${platform_arch}
+        cleanup_unstable ${platform_arch}
+      ;;
+    esac
+  done
+
+  # Cleanup
+  rm -r ${in_dir}/${build_id}
+
+  # Run mirrorbits refresh
+  mirrorbits refresh
+
+  time_end=$( date +%s )
+  time_total=$( echo "${time_end} - ${time_start}" | bc )
+
+  echo "Finished at $( date ) in ${time_total} seconds" 1>&1
+  echo "Finished at $( date ) in ${time_total} seconds" 1>&2
+
+) 300>/var/log/os-pack.lock
+
+rm /var/log/os-pack.lock
+exit 0


### PR DESCRIPTION
### Description

The changes in this PR are required for the Server + Web CI migration from Azure DevOps to GH Actions.
It adds a new collect server script to replace the old and extracts some its parts wo other GitHub Action Workflows.

A very basic schematic on what triggers what within this repo:
![CI-schematic](https://user-images.githubusercontent.com/33120068/132920325-ba7ddad2-a788-4837-9b78-62546bb5f9ed.jpg)
*edit*: there I a missing trigger link from the server publish-API workflow to the VPS where it uploads the spec to **and** runs `mirrorbits refresh` (see the [server PR](jellyfin/jellyfin#6364) workflow for how)

### Change(s)

* add new collect-server script for OS and fiel bundles
* extracted container image build to GitHub workflow
  * updated Dockerfiles to include OCI labels and their formating
* added editorconfig and updated gitignore

### TODO(s)

* [ ] request new GitHub secrets to be added 
  * [ ] JF_BOT_TOKEN
  * [ ] QUAY_USERNAME - Quay Robot Account Name
  * [ ] QUAY_TOKEN - Quay Robot Account
  * [ ] DOCKERHUB_USERNAME - DockerHub Account Name
  * [ ] DOCKERHUB_TOKEN - DockerHub Token

### Before Merge Checklist:

* [ ] **ALL** TODOs done
* [ ] **AT LEAST 3** 'Core' Members approved
* [ ] merge this PR **FIRST** before `server` and `web`

### Issue(s)

* relates to jellyfin/jellyfin#6364
* relates to jellyfin/jellyfin-web#2897