### PR TITLE
Add DockerHub -> GHCR sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,50 @@
+name: Sync DockerHub images with GHCR 🔁
+
+## This workflow is a temporal solution for having all our docker images synced to GHCR. However,
+## as soon as all the repo's CI is migrated to GitHub Actions, this can be removed.
+##
+## Project tracking the progress: https://github.com/orgs/jellyfin/projects/31
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    name: Image sync 🔁
+    # Errors will probably be caused by excesses in API quota, so we can safely continue.
+    # Remaining workflows will be removed in the next scheduled run.
+    continue-on-error: true 
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - 'jellyfin/jellyfin'
+
+    steps:
+      - name: Clone repository
+      - uses: actions/checkout@v2.3.4
+
+      ## Logging in to DockerHub allows for more pulls without hitting DockerHub's quota (100 vs 200).
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1.10.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.JF_BOT_TOKEN }}
+
+      - name: Set correct permissions
+        run: chmod +x sync_image_ghcr.sh
+
+      - name: Run syncing script
+        run: ./sync_image_ghcr.sh ${{ matrix.image }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.JF_BOT_TOKEN }}

--- a/sync_image_ghcr.sh
+++ b/sync_image_ghcr.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -e
+# Simple script that pushes missing/outdated tags from an image in DockerHub to GHCR, skipping up-to-date tags 
+# GitHub package registry. You need to be logged in using 'docker login' first: https://docs.github.com/es/packages/working-with-a-github-packages-registry/working-with-the-container-registry
+target_repo="ghcr.io"
+tag_file="tag_list.txt"
+original_image="$1"
+rm -rf $tag_file
+url="https://hub.docker.com/v2/repositories/${original_image}/tags"
+tag_count=$(wget -q "$url" -O - | jq -r '.count')
+
+echo "Fetching tags from DockerHub..."
+while true; do
+	results=$(wget -q "$url" -O - | jq -r '.')
+	url=$(echo "$results" | jq -r '.next')
+	echo "$results" | jq -r '.results[] | {name: .name, last_pushed: .tag_last_pushed, digests: [.images[].digest]}' >> $tag_file
+	if [ "${url}" = "null" ]
+	then
+		break
+	else
+		continue
+	fi
+done;
+unset results, url
+
+sorted=$(cat "$tag_file" | jq -s 'sort_by(.last_pushed)')
+echo "$sorted" > $tag_file
+file_tag_count=$(jq length "$tag_file")
+
+if [ $tag_count = $file_tag_count ]
+then
+	echo -e "All the data was retrieved correctly. Pushing missing/modified tags to DockerHub...\n"
+else
+	echo "The retrieved data doesn't match the amount of tags expected by Docker API. Exiting script..."
+	exit 1
+fi
+
+unset sorted, file_tag_count, tag_count
+
+## This token is that GitHub provides is used to access the registry in read-only, so users are able to
+## use GHCR without signing up to GitHub. By using this token for checking for the published images, we don't consume
+## our own API quota.
+dest_token=$(wget -q https://ghcr.io/token\?scope\="repository:${original_image}:pull" -O - | jq -r '.token')
+tag_names=$(cat "$tag_file" | jq -r '.[] | .name')
+
+while read -r line; do
+	tag="$line"
+	source_digests=$(cat "$tag_file" | jq -r --arg TAG_NAME "$tag" '.[] | select(.name == $TAG_NAME) | .digests | sort | .[]' | cat)
+	target_manifest=$(wget --header="Authorization: Bearer ${dest_token}" -q https://${target_repo}/v2/${original_image}/manifests/${tag} -O - | cat)
+	target_digests=$(echo "$target_manifest" | jq '.manifests | .[] | .digest' | jq -s '. | sort' | jq -r '.[]' | cat)
+	if [ "$source_digests" = "$target_digests" ]
+	then
+		echo The tag $tag is fully updated in $target_repo
+		continue
+	else
+		echo Updating $tag in $target_repo
+		docker pull $original_image:$tag
+		docker tag $original_image:$tag $target_repo/$original_image:$tag
+		docker push $target_repo/$original_image:$tag
+
+		# Delete pushed images from local system
+		docker image rm $original_image:$tag
+		docker image rm $target_repo/$original_image:$tag
+	fi
+done <<< $tag_names
+
+rm -rf $tag_file
+echo -e "\nAll the tags have been updated successfully"
+exit 0


### PR DESCRIPTION
All the CI migration and revamp is [in full swing](https://github.com/orgs/jellyfin/projects/31) and it will simplify the publishing of container images to multiple registries beside DockerHub (kudos to @h1dden-da3m0n for all the huge amount of work!)

However, it's likely that it won't be ready for 10.8 and, once implemented, all the images that were previously available in DockerHub won't be available in GHCR. This might frustrate some users and looks like half-baked.

In order to have one more "new thing" for 10.8, and to provide an alternate method to access our software in the meantime (as GHCR is becoming a quite popular alternative), this workflow will run at midnight to check which container tags are missing/outdated in GHCR and update those from the ones present in DockerHub, skipping everything that it's already up-to-date in GHCR. **This means that all the previous versions that are present in DockerHub will be present in GHCR as well!**

As soon as all the CI work is complete, this workflow can be removed and is no longer necessary.


## Needed tokens
This PR needs that the following org-wide secrets are made available in this repo:

* **JF_BOT_TOKEN**: For pushing images to GHCR. Needs ``write/read:packages``, ``delete:packages``, ``read:org``
* **DOCKERHUB_TOKEN**: Needed to increase the 6-hour DockerHub pull limit from 100 to 200
* **DOCKERHUB_USERNAME**: Needed to increase the 6-hour DockerHub pull limit from 100 to 200

(When DockerHub limits are reached, the workflow will fail. However, as the script only pulls and push what it's outdated in GHCR, the process will be continued where it was left off in the next schedule, after the API quota is resetted)