### PR TITLE
Upgrade DockerFile to match Main Repository Docker

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -3,7 +3,7 @@ ARG TARGET_RELEASE=stable
 
 FROM jellyfin/jellyfin-server:${TARGET_RELEASE}-amd64 as server
 FROM jellyfin/jellyfin-web:${TARGET_RELEASE} as web
-FROM debian:buster-slim
+FROM debian:stable-slim
 
 # Default environment variables for the Jellyfin invocation
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT="1" \
@@ -19,10 +19,10 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT="1" \
     JELLYFIN_FFMPEG="/usr/lib/jellyfin-ffmpeg/ffmpeg"
 
 # https://github.com/intel/compute-runtime/releases
-ARG GMMLIB_VERSION=20.3.2
-ARG IGC_VERSION=1.0.5435
-ARG NEO_VERSION=20.46.18421
-ARG LEVEL_ZERO_VERSION=1.0.18421
+ARG GMMLIB_VERSION=21.2.1
+ARG IGC_VERSION=1.0.8744
+ARG NEO_VERSION=21.40.21182
+ARG LEVEL_ZERO_VERSION=1.2.21182
 
 # Install dependencies:
 # mesa-va-drivers: needed for AMD VAAPI. Mesa >= 20.1 is required for HEVC transcoding.


### PR DESCRIPTION
This PR is my attempt to upgrade the docker image at dockerhub: https://hub.docker.com/r/jellyfin/jellyfin/

It seems to have fallen behind in regards to base images and dependencies from intel.

This does upgrade it to a more [recent version](https://github.com/intel/compute-runtime/releases/tag/21.40.21182) of the dependencies but should still be compatible with older versions (this is from my personal testing with an i3 10100)