### PR TITLE
Cleanup Docker images

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -12,7 +12,6 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT="1" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US:en" \
-    JELLYFIN_MEDIA_DIR="/media" \
     JELLYFIN_DATA_DIR="/config" \
     JELLYFIN_CACHE_DIR="/cache" \
     JELLYFIN_CONFIG_DIR="/config/config" \
@@ -25,16 +24,16 @@ ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 
 # https://github.com/intel/compute-runtime/releases
 ARG GMMLIB_VERSION=22.0.2
-ARG IGC_VERSION=1.0.10395
-ARG NEO_VERSION=22.08.22549
-ARG LEVEL_ZERO_VERSION=1.3.22549
+ARG IGC_VERSION=1.0.10409
+ARG NEO_VERSION=22.09.22577
+ARG LEVEL_ZERO_VERSION=1.3.22577
 
 # Install dependencies:
 # mesa-va-drivers: needed for AMD VAAPI. Mesa >= 20.1 is required for HEVC transcoding.
 # curl: healthcheck
 RUN apt-get update \
  && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl wget apt-transport-https \
- && wget -O - https://repo.jellyfin.org/jellyfin_team.gpg.key | apt-key add - \
+ && curl -fsSL https://repo.jellyfin.org/jellyfin_team.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/debian-jellyfin.gpg \
  && echo 'deb [arch=amd64] https://repo.jellyfin.org/debian bullseye main' > /etc/apt/sources.list.d/jellyfin.list \
  && cat /etc/apt/sources.list.d/jellyfin.list \
  && apt-get update \
@@ -56,15 +55,15 @@ RUN apt-get update \
  && apt-get clean autoclean -y \
  && apt-get autoremove -y \
  && rm -rf /var/lib/apt/lists/* \
- && mkdir -p ${JELLYFIN_MEDIA_DIR} ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
- && chmod 777 ${JELLYFIN_MEDIA_DIR} ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
+ && mkdir -p ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
+ && chmod 777 ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
  && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
 
 COPY --from=server /jellyfin /jellyfin
 COPY --from=web /jellyfin-web /jellyfin/jellyfin-web
 
 EXPOSE 8096
-VOLUME ${JELLYFIN_MEDIA_DIR} ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR}
+VOLUME ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR}
 ENTRYPOINT [ "/jellyfin/jellyfin" ]
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=10s --retries=3 \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -14,7 +14,6 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT="1" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US:en" \
-    JELLYFIN_MEDIA_DIR="/media" \
     JELLYFIN_DATA_DIR="/config" \
     JELLYFIN_CACHE_DIR="/cache" \
     JELLYFIN_CONFIG_DIR="/config/config" \
@@ -23,27 +22,26 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT="1" \
     JELLYFIN_FFMPEG="/usr/lib/jellyfin-ffmpeg/ffmpeg"
 
 # Install dependencies:
-#   libomxil-bellagio0: needed for OpenMax IL
 #   curl: healcheck
 RUN apt-get update \
- && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl wget apt-transport-https \
- && wget -O - https://repo.jellyfin.org/jellyfin_team.gpg.key | apt-key add - \
+ && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl wget \
+ && curl -fsSL https://repo.jellyfin.org/jellyfin_team.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/debian-jellyfin.gpg \
  && echo 'deb [arch=arm64] https://repo.jellyfin.org/debian bullseye main' > /etc/apt/sources.list.d/jellyfin.list \
  && apt-get update \
- && apt-get install --no-install-recommends --no-install-suggests -y libomxil-bellagio0 libomxil-bellagio-bin jellyfin-ffmpeg openssl locales libfontconfig1 libfreetype6 \
- && apt-get remove gnupg wget apt-transport-https -y \
+ && apt-get install --no-install-recommends --no-install-suggests -y jellyfin-ffmpeg openssl locales libfontconfig1 libfreetype6 \
+ && apt-get remove gnupg wget -y \
  && apt-get clean autoclean -y \
  && apt-get autoremove -y \
  && rm -rf /var/lib/apt/lists/* \
- && mkdir -p ${JELLYFIN_MEDIA_DIR} ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
- && chmod 777 ${JELLYFIN_MEDIA_DIR} ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
+ && mkdir -p ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
+ && chmod 777 ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
  && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
 
 COPY --from=server /jellyfin /jellyfin
 COPY --from=web /jellyfin-web /jellyfin/jellyfin-web
 
 EXPOSE 8096
-VOLUME ${JELLYFIN_MEDIA_DIR} ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR}
+VOLUME ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR}
 ENTRYPOINT [ "/jellyfin/jellyfin" ]
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=10s --retries=3 \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -14,7 +14,6 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT="1" \
     LC_ALL="en_US.UTF-8" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US:en" \
-    JELLYFIN_MEDIA_DIR="/media" \
     JELLYFIN_DATA_DIR="/config" \
     JELLYFIN_CACHE_DIR="/cache" \
     JELLYFIN_CONFIG_DIR="/config/config" \
@@ -23,31 +22,26 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT="1" \
     JELLYFIN_FFMPEG="/usr/lib/jellyfin-ffmpeg/ffmpeg"
 
 # Install dependencies:
-#   libomxil-bellagio0: needed for OpenMax IL
-#   libraspberrypi0: needed for MMAL component of ffmpeg (from Raspberry Pi)
-#   libva2: needed for VAAPI
 #   curl: healthcheck
 RUN apt-get update \
- && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl wget apt-transport-https \
- && wget -O - https://repo.jellyfin.org/jellyfin_team.gpg.key | apt-key add - \
- && wget -O - https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x6587ffd6536b8826e88a62547876ae518cbcf2f2 | apt-key add - \
+ && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl wget \
+ && curl -fsSL https://repo.jellyfin.org/jellyfin_team.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/debian-jellyfin.gpg \
  && echo 'deb [arch=armhf] https://repo.jellyfin.org/debian bullseye main' > /etc/apt/sources.list.d/jellyfin.list \
- && echo 'deb http://ppa.launchpad.net/ubuntu-raspi2/ppa-nightly/ubuntu focal main'>> /etc/apt/sources.list.d/raspbins.list \
  && apt-get update \
- && apt-get install --no-install-recommends --no-install-suggests -y libva2 vainfo libraspberrypi0 libomxil-bellagio0 libomxil-bellagio-bin jellyfin-ffmpeg openssl locales libfontconfig1 libfreetype6 \
- && apt-get remove gnupg wget apt-transport-https -y \
+ && apt-get install --no-install-recommends --no-install-suggests -y jellyfin-ffmpeg openssl locales libfontconfig1 libfreetype6 \
+ && apt-get remove gnupg wget -y \
  && apt-get clean autoclean -y \
  && apt-get autoremove -y \
  && rm -rf /var/lib/apt/lists/* \
- && mkdir -p ${JELLYFIN_MEDIA_DIR} ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
- && chmod 777 ${JELLYFIN_MEDIA_DIR} ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
+ && mkdir -p ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
+ && chmod 777 ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR} \
  && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
 
 COPY --from=server /jellyfin /jellyfin
 COPY --from=web /jellyfin-web /jellyfin/jellyfin-web
 
 EXPOSE 8096
-VOLUME ${JELLYFIN_MEDIA_DIR} ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR}
+VOLUME ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR}
 ENTRYPOINT [ "/jellyfin/jellyfin" ]
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=10s --retries=3 \


### PR DESCRIPTION
* Remove unneeded OMX and MMAL libs (jellyfin/jellyfin-ffmpeg/pull/77)
* Remove `apt-transport-https` since it's not required in bullseye anymore
* Migrate from deprecated `apt-key` to `/etc/apt/trusted.gpg.d`
* Update Intel compute runtime
* Changes from #15