### PR TITLE
Update jellyfin-ffmpeg dep to jellyfin-ffmpeg5

### DIFF
--- a/jellyfin.debian
+++ b/jellyfin.debian
@@ -7,7 +7,7 @@ Standards-Version: 3.9.2
 Package: jellyfin
 Version: X.Y.Z
 Maintainer: Jellyfin Packaging Team <packaging@jellyfin.org>
-Depends: jellyfin-server (>= X.Y.Z), jellyfin-web (>= X.Y.Z), jellyfin-ffmpeg (>= 4.2.1-2)
+Depends: jellyfin-server (>= X.Y.Z), jellyfin-web (>= X.Y.Z), jellyfin-ffmpeg5 (>= 5.0.0)
 Description: Provides the Jellyfin Free Software Media System
  Provides the full Jellyfin experience, including both the server and web interface.
 


### PR DESCRIPTION
For use by the 5.0.0 releases of ffmpeg, to keep them isolated from the
4.x releases. Suboptimal but the only way around the problem.