### PR TITLE
Add combined linux packages for arm64-musl

### DIFF
--- a/collect-server.azure.sh
+++ b/collect-server.azure.sh
@@ -50,6 +50,7 @@ linux_static_arches=(
     "amd64"
     "amd64-musl"
     "arm64"
+    "arm64-musl"
     "armhf"
 )
 docker_arches=(

--- a/do-combine-portable-linux.sh
+++ b/do-combine-portable-linux.sh
@@ -12,6 +12,7 @@ linux_static_arches=(
     "amd64"
     "amd64-musl"
     "arm64"
+    "arm64-musl"
     "armhf"
 )
 docker_arches=(

--- a/prerelease.sh
+++ b/prerelease.sh
@@ -37,6 +37,7 @@ linux_static_arches=(
     "amd64"
     "amd64-musl"
     "arm64"
+    "arm64-musl"
     "armhf"
 )
 docker_arches=(

--- a/rebuild-docker.sh
+++ b/rebuild-docker.sh
@@ -37,6 +37,7 @@ linux_static_arches=(
     "amd64"
     "amd64-musl"
     "arm64"
+    "arm64-musl"
     "armhf"
 )
 docker_arches=(


### PR DESCRIPTION
Due to the relative complexity of the build mechanism and the non-portability of the scripts (including, based on my glances, the one labeled -portable-), this is untested. It simply adds  "arm64-musl" alongside any mentions of "amd64-musl".

Hope it can be tested and implemented because I'm looking forward to trying out the arm64-musl build.