### PR TITLE
Fix Docker healthcheck output

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -68,4 +68,4 @@ VOLUME ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR}
 ENTRYPOINT [ "/jellyfin/jellyfin" ]
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=10s --retries=3 \
-     CMD curl -Lk "${HEALTHCHECK_URL}" || exit 1
+     CMD curl -Lk -fsS "${HEALTHCHECK_URL}" || exit 1

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -45,4 +45,4 @@ VOLUME ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR}
 ENTRYPOINT [ "/jellyfin/jellyfin" ]
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=10s --retries=3 \
-     CMD curl -Lk "${HEALTHCHECK_URL}" || exit 1
+     CMD curl -Lk -fsS "${HEALTHCHECK_URL}" || exit 1

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -45,4 +45,4 @@ VOLUME ${JELLYFIN_DATA_DIR} ${JELLYFIN_CACHE_DIR}
 ENTRYPOINT [ "/jellyfin/jellyfin" ]
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=10s --retries=3 \
-     CMD curl -Lk "${HEALTHCHECK_URL}" || exit 1
+     CMD curl -Lk -fsS "${HEALTHCHECK_URL}" || exit 1


### PR DESCRIPTION
The current healthcheck command results in progress info being output. Add -f/--fail, -s/--silent, -S/--show-error options to avoid progress output, but still show error messages if something goes wrong.

This is the same change as jellyfin/jellyfin#8529.