### PR TITLE
Update intel compute runtime to 22.43.24595.30

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -24,10 +24,10 @@ ENV NVIDIA_VISIBLE_DEVICES="all"
 ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 
 # https://github.com/intel/compute-runtime/releases
-ARG GMMLIB_VERSION=22.2.0
-ARG IGC_VERSION=1.0.12149.1
-ARG NEO_VERSION=22.39.24347
-ARG LEVEL_ZERO_VERSION=1.3.24347
+ARG GMMLIB_VERSION=22.3.0
+ARG IGC_VERSION=1.0.12504.5
+ARG NEO_VERSION=22.43.24595.30
+ARG LEVEL_ZERO_VERSION=1.3.24595.30
 
 # Install dependencies:
 # mesa-va-drivers: needed for AMD VAAPI. Mesa >= 20.1 is required for HEVC transcoding.


### PR DESCRIPTION
The latest IGC release fixed the compatibility with Debian bullseye.