### PR TITLE
Upgrade base images to Debian 12 Bookworm

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,9 +1,12 @@
 # By default build for stable; unstable must set this explicitly
 ARG TARGET_RELEASE=stable
+ARG DISTRO=debian
+ARG CODENAME=bookworm
+ARG ARCH=amd64
 
-FROM jellyfin/jellyfin-server:${TARGET_RELEASE}-amd64 as server
+FROM jellyfin/jellyfin-server:${TARGET_RELEASE}-${ARCH} as server
 FROM jellyfin/jellyfin-web:${TARGET_RELEASE} as web
-FROM debian:bookworm-slim
+FROM debian:${CODENAME}-slim
 
 ENV HEALTHCHECK_URL=http://localhost:8096/health
 
@@ -32,10 +35,14 @@ ARG LEVEL_ZERO_VERSION=1.3.23529
 # Install dependencies:
 # curl: healthcheck
 RUN apt-get update \
- && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl wget apt-transport-https \
- && curl -fsSL https://repo.jellyfin.org/jellyfin_team.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/debian-jellyfin.gpg \
- && echo 'deb [arch=amd64] https://repo.jellyfin.org/debian bullseye main' > /etc/apt/sources.list.d/jellyfin.list \
- && cat /etc/apt/sources.list.d/jellyfin.list \
+ && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl wget
+COPY jellyfin.sources /etc/apt/sources.list.d/jellyfin.sources
+RUN mkdir /etc/apt/keyrings \
+ && curl -fsSL https://repo.jellyfin.org/jellyfin_team.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/jellyfin.gpg \
+ && sed -i -e "s/DISTRO/$DISTRO/" /etc/apt/sources.list.d/jellyfin.sources \
+ && sed -i -e "s/CODENAME/$CODENAME/" /etc/apt/sources.list.d/jellyfin.sources \
+ && sed -i -e "s/ARCH/$ARCH/" /etc/apt/sources.list.d/jellyfin.sources \
+ && cat /etc/apt/sources.list.d/jellyfin.sources \
  && apt-get update \
  && apt-get install --no-install-recommends --no-install-suggests -y jellyfin-ffmpeg6 openssl locales libfontconfig1 libfreetype6 \
 # Intel VAAPI Tone mapping dependencies:

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -30,7 +30,6 @@ ARG NEO_VERSION=22.25.23529
 ARG LEVEL_ZERO_VERSION=1.3.23529
 
 # Install dependencies:
-# mesa-va-drivers: needed for AMD VAAPI. Mesa >= 20.1 is required for HEVC transcoding.
 # curl: healthcheck
 RUN apt-get update \
  && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl wget apt-transport-https \
@@ -38,7 +37,7 @@ RUN apt-get update \
  && echo 'deb [arch=amd64] https://repo.jellyfin.org/debian bullseye main' > /etc/apt/sources.list.d/jellyfin.list \
  && cat /etc/apt/sources.list.d/jellyfin.list \
  && apt-get update \
- && apt-get install --no-install-recommends --no-install-suggests -y mesa-va-drivers jellyfin-ffmpeg5 openssl locales libfontconfig1 libfreetype6 \
+ && apt-get install --no-install-recommends --no-install-suggests -y jellyfin-ffmpeg6 openssl locales libfontconfig1 libfreetype6 \
 # Intel VAAPI Tone mapping dependencies:
 # Prefer NEO to Beignet since the latter one doesn't support Comet Lake or newer for now.
 # Do not use the intel-opencl-icd package from repo since they will not build with RELEASE_WITH_REGKEYS enabled.

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -3,7 +3,7 @@ ARG TARGET_RELEASE=stable
 
 FROM jellyfin/jellyfin-server:${TARGET_RELEASE}-amd64 as server
 FROM jellyfin/jellyfin-web:${TARGET_RELEASE} as web
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ENV HEALTHCHECK_URL=http://localhost:8096/health
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -28,7 +28,7 @@ RUN apt-get update \
  && curl -fsSL https://repo.jellyfin.org/jellyfin_team.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/debian-jellyfin.gpg \
  && echo 'deb [arch=arm64] https://repo.jellyfin.org/debian bullseye main' > /etc/apt/sources.list.d/jellyfin.list \
  && apt-get update \
- && apt-get install --no-install-recommends --no-install-suggests -y jellyfin-ffmpeg5 openssl locales libfontconfig1 libfreetype6 \
+ && apt-get install --no-install-recommends --no-install-suggests -y jellyfin-ffmpeg6 openssl locales libfontconfig1 libfreetype6 \
  && apt-get remove gnupg wget -y \
  && apt-get clean autoclean -y \
  && apt-get autoremove -y \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -4,7 +4,7 @@ ARG TARGET_RELEASE=stable
 FROM multiarch/qemu-user-static:x86_64-aarch64 as qemu
 FROM jellyfin/jellyfin-server:${TARGET_RELEASE}-arm64 as server
 FROM jellyfin/jellyfin-web:${TARGET_RELEASE} as web
-FROM arm64v8/debian:bullseye-slim
+FROM arm64v8/debian:bookworm-slim
 COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
 
 ENV HEALTHCHECK_URL=http://localhost:8096/health

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,10 +1,13 @@
 # By default build for stable; unstable must set this explicitly
 ARG TARGET_RELEASE=stable
+ARG DISTRO=debian
+ARG CODENAME=bookworm
+ARG ARCH=arm64
 
 FROM multiarch/qemu-user-static:x86_64-aarch64 as qemu
-FROM jellyfin/jellyfin-server:${TARGET_RELEASE}-arm64 as server
+FROM jellyfin/jellyfin-server:${TARGET_RELEASE}-${ARCH} as server
 FROM jellyfin/jellyfin-web:${TARGET_RELEASE} as web
-FROM arm64v8/debian:bookworm-slim
+FROM arm64v8/debian:${CODENAME}-slim
 COPY --from=qemu /usr/bin/qemu-aarch64-static /usr/bin
 
 ENV HEALTHCHECK_URL=http://localhost:8096/health
@@ -21,12 +24,15 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT="1" \
     JELLYFIN_WEB_DIR="/jellyfin/jellyfin-web" \
     JELLYFIN_FFMPEG="/usr/lib/jellyfin-ffmpeg/ffmpeg"
 
-# Install dependencies:
-#   curl: healcheck
 RUN apt-get update \
- && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl wget \
- && curl -fsSL https://repo.jellyfin.org/jellyfin_team.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/debian-jellyfin.gpg \
- && echo 'deb [arch=arm64] https://repo.jellyfin.org/debian bullseye main' > /etc/apt/sources.list.d/jellyfin.list \
+ && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl wget
+COPY jellyfin.sources /etc/apt/sources.list.d/jellyfin.sources
+RUN mkdir /etc/apt/keyrings \
+ && curl -fsSL https://repo.jellyfin.org/jellyfin_team.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/jellyfin.gpg \
+ && sed -i -e "s/DISTRO/$DISTRO/" /etc/apt/sources.list.d/jellyfin.sources \
+ && sed -i -e "s/CODENAME/$CODENAME/" /etc/apt/sources.list.d/jellyfin.sources \
+ && sed -i -e "s/ARCH/$ARCH/" /etc/apt/sources.list.d/jellyfin.sources \
+ && cat /etc/apt/sources.list.d/jellyfin.sources \
  && apt-get update \
  && apt-get install --no-install-recommends --no-install-suggests -y jellyfin-ffmpeg6 openssl locales libfontconfig1 libfreetype6 \
  && apt-get remove gnupg wget -y \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -28,7 +28,7 @@ RUN apt-get update \
  && curl -fsSL https://repo.jellyfin.org/jellyfin_team.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/debian-jellyfin.gpg \
  && echo 'deb [arch=armhf] https://repo.jellyfin.org/debian bullseye main' > /etc/apt/sources.list.d/jellyfin.list \
  && apt-get update \
- && apt-get install --no-install-recommends --no-install-suggests -y jellyfin-ffmpeg5 openssl locales libfontconfig1 libfreetype6 \
+ && apt-get install --no-install-recommends --no-install-suggests -y jellyfin-ffmpeg6 openssl locales libfontconfig1 libfreetype6 \
  && apt-get remove gnupg wget -y \
  && apt-get clean autoclean -y \
  && apt-get autoremove -y \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -4,7 +4,7 @@ ARG TARGET_RELEASE=stable
 FROM multiarch/qemu-user-static:x86_64-arm as qemu
 FROM jellyfin/jellyfin-server:${TARGET_RELEASE}-armhf as server
 FROM jellyfin/jellyfin-web:${TARGET_RELEASE} as web
-FROM arm32v7/debian:bullseye-slim
+FROM arm32v7/debian:bookworm-slim
 COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin
 
 ENV HEALTHCHECK_URL=http://localhost:8096/health

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,10 +1,13 @@
 # By default build for stable; unstable must set this explicitly
 ARG TARGET_RELEASE=stable
+ARG DISTRO=debian
+ARG CODENAME=bookworm
+ARG ARCH=armhf
 
 FROM multiarch/qemu-user-static:x86_64-arm as qemu
-FROM jellyfin/jellyfin-server:${TARGET_RELEASE}-armhf as server
+FROM jellyfin/jellyfin-server:${TARGET_RELEASE}-${ARCH} as server
 FROM jellyfin/jellyfin-web:${TARGET_RELEASE} as web
-FROM arm32v7/debian:bookworm-slim
+FROM arm32v7/debian:${CODENAME}-slim
 COPY --from=qemu /usr/bin/qemu-arm-static /usr/bin
 
 ENV HEALTHCHECK_URL=http://localhost:8096/health
@@ -21,12 +24,15 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT="1" \
     JELLYFIN_WEB_DIR="/jellyfin/jellyfin-web" \
     JELLYFIN_FFMPEG="/usr/lib/jellyfin-ffmpeg/ffmpeg"
 
-# Install dependencies:
-#   curl: healthcheck
 RUN apt-get update \
- && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl wget \
- && curl -fsSL https://repo.jellyfin.org/jellyfin_team.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/debian-jellyfin.gpg \
- && echo 'deb [arch=armhf] https://repo.jellyfin.org/debian bullseye main' > /etc/apt/sources.list.d/jellyfin.list \
+ && apt-get install --no-install-recommends --no-install-suggests -y ca-certificates gnupg curl wget
+COPY jellyfin.sources /etc/apt/sources.list.d/jellyfin.sources
+RUN mkdir /etc/apt/keyrings \
+ && curl -fsSL https://repo.jellyfin.org/jellyfin_team.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/jellyfin.gpg \
+ && sed -i -e "s/DISTRO/$DISTRO/" /etc/apt/sources.list.d/jellyfin.sources \
+ && sed -i -e "s/CODENAME/$CODENAME/" /etc/apt/sources.list.d/jellyfin.sources \
+ && sed -i -e "s/ARCH/$ARCH/" /etc/apt/sources.list.d/jellyfin.sources \
+ && cat /etc/apt/sources.list.d/jellyfin.sources \
  && apt-get update \
  && apt-get install --no-install-recommends --no-install-suggests -y jellyfin-ffmpeg6 openssl locales libfontconfig1 libfreetype6 \
  && apt-get remove gnupg wget -y \

--- a/jellyfin.sources
+++ b/jellyfin.sources
@@ -1,0 +1,6 @@
+Types: deb
+URIs: https://repo.jellyfin.org/DISTRO
+Suites: CODENAME
+Components: main
+Architectures: ARCH
+Signed-By: /etc/apt/keyrings/jellyfin.gpg


### PR DESCRIPTION
Additionally removes `mesa-va-drivers` and upgrades to `jellyfin-ffmpeg6`.